### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
     "version"     : "*",
     "authors"     : [ "Bartłomiej Palmowski", "Andy Weidenbaum" ],
     "description" : "xxHash bindings for Perl6",
-    "license"     : "http://unlicense.org/UNLICENSE",
+    "license"     : "Unlicense",
     "source-type" : "git",
     "source-url"  : "git://github.com/atweiden/digest-xxhash.git",
     "support"     : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license